### PR TITLE
Fix tab has_content status bug

### DIFF
--- a/sidebar/modules/page-data-manager.js
+++ b/sidebar/modules/page-data-manager.js
@@ -386,6 +386,18 @@ const handlePageDataLoaded = async (pageInfo) => {
     await window.TabManager.loadTabChatHistory(activeTabId, pageInfo.chatHistory);
     logger.info(`Loaded chat history for active tab: ${activeTabId}`);
 
+    // After loading chat history, compute has-content for all tabs and refresh UI
+    try {
+      if (window.TabManager.updateTabsContentStates) {
+        await window.TabManager.updateTabsContentStates();
+      }
+      if (window.TabManager.renderCurrentTabsState) {
+        await window.TabManager.renderCurrentTabsState();
+      }
+    } catch (stateError) {
+      logger.warn('Failed to update tabs content states after initial load:', stateError);
+    }
+
     // Fix existing message layouts
     setTimeout(() => {
       ChatManager.fixExistingMessageLayouts(elements.chatContainer);


### PR DESCRIPTION
Update tab content states after loading chat history to correctly reflect existing conversations when the sidebar opens.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cfcd97b-2526-4b25-8edf-86abe130c5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0cfcd97b-2526-4b25-8edf-86abe130c5df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

