### PR TITLE
Refactor options layout into tabs

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -45,248 +45,274 @@
     
     <main>
       <form id="settingsForm">
-        <!-- Two Column Layout -->
-        <div class="main-content-wrapper">
-          <!-- Left Sidebar -->
-          <div class="left-sidebar">
-            
-            <!-- Default Model -->
-            <section class="settings-section sidebar-section">
-              <h2 data-i18n="options_basic_settings_title">Basic Settings</h2>
-              <div class="form-group cache-item-group">
-                <label data-i18n="options_cache_label">Local Data:</label>
-                <p><span id="totalCacheDisplay">0B</span></p>
-                <button type="button" id="clearAllCacheBtn" class="secondary-btn small-btn" data-i18n="common_clear">Clear</button>
-              </div>
-              <div class="floating-label-field">
-                <select id="defaultModelSelect" name="defaultModelSelect">
-                  <!-- Options will be populated dynamically -->
-                </select>
-                <label for="defaultModelSelect" class="floating-label" data-i18n="common_model">Model</label>
-              </div>
-            
-              <div class="floating-label-field">
-                <div class="custom-multi-select" id="branchModelSelect" name="branchModelSelect">
-                  <div class="multi-select-container">
-                    <div class="selected-items" id="selected-branch-models">
-                      <span class="no-models-selected"></span>
-                    </div>
-                    <div class="multi-select-dropdown">
-                      <button type="button" class="dropdown-toggle" id="branch-models-toggle">
-                        <i class="material-icons">arrow_drop_down</i>
-                      </button>
-                      <div class="dropdown-options" id="branch-models-dropdown">
-                        <!-- Options will be populated dynamically -->
+        <div class="tabbed-layout">
+          <div class="tab-list" role="tablist" aria-orientation="vertical">
+            <button type="button" class="tab-button active" role="tab" aria-selected="true" data-tab-target="basic">
+              <span data-i18n="options_basic_settings_title">Basic Settings</span>
+            </button>
+            <button type="button" class="tab-button" role="tab" aria-selected="false" data-tab-target="quick-inputs">
+              <span data-i18n="options_quick_input_tabs_title">Quick Input Tabs</span>
+            </button>
+            <button type="button" class="tab-button" role="tab" aria-selected="false" data-tab-target="models">
+              <span data-i18n="options_language_models_title">Language Models</span>
+            </button>
+            <button type="button" class="tab-button" role="tab" aria-selected="false" data-tab-target="cloud-sync">
+              <span data-i18n="options_cloud_sync_title">Cloud Sync</span>
+            </button>
+            <button type="button" class="tab-button" role="tab" aria-selected="false" data-tab-target="blacklist">
+              <span data-i18n="options_blacklist_settings_title">Blacklist Settings</span>
+            </button>
+          </div>
+          <div class="tab-panels">
+            <section id="tab-basic" class="tab-panel active" role="tabpanel">
+              <section class="settings-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_basic_settings_title">Basic Settings</h2>
+                </div>
+                <div class="form-group cache-item-group">
+                  <label data-i18n="options_cache_label">Local Data:</label>
+                  <p><span id="totalCacheDisplay">0B</span></p>
+                  <button type="button" id="clearAllCacheBtn" class="secondary-btn small-btn" data-i18n="common_clear">Clear</button>
+                </div>
+                <div class="floating-label-field">
+                  <select id="defaultModelSelect" name="defaultModelSelect">
+                    <!-- Options will be populated dynamically -->
+                  </select>
+                  <label for="defaultModelSelect" class="floating-label" data-i18n="common_model">Model</label>
+                </div>
+
+                <div class="floating-label-field">
+                  <div class="custom-multi-select" id="branchModelSelect" name="branchModelSelect">
+                    <div class="multi-select-container">
+                      <div class="selected-items" id="selected-branch-models">
+                        <span class="no-models-selected"></span>
+                      </div>
+                      <div class="multi-select-dropdown">
+                        <button type="button" class="dropdown-toggle" id="branch-models-toggle">
+                          <i class="material-icons">arrow_drop_down</i>
+                        </button>
+                        <div class="dropdown-options" id="branch-models-dropdown">
+                          <!-- Options will be populated dynamically -->
+                        </div>
                       </div>
                     </div>
                   </div>
+                  <label for="branchModelSelect" class="floating-label" data-i18n="common_branch_models">Branch Models</label>
                 </div>
-                <label for="branchModelSelect" class="floating-label" data-i18n="common_branch_models">Branch Models</label>
-              </div>
-            
-              <div class="floating-label-field">
-                <select id="theme" name="theme">
-                  <option value="light" data-i18n="options_theme_light">Light</option>
-                  <option value="dark" data-i18n="options_theme_dark">Dark</option>
-                  <option value="system" data-i18n="options_theme_system">System</option>
-                </select>
-                <label for="theme" class="floating-label" data-i18n="options_theme_label">Theme</label>
-              </div>
-            
-              <div class="floating-label-field">
-                <select id="languageSelector" name="language">
-                  <option value="en" data-i18n="options_language_english">English</option>
-                  <option value="zh_CN" data-i18n="options_language_chinese">简体中文</option>
-                  <!-- More languages can be added here -->
-                </select>
-                <label for="languageSelector" class="floating-label" data-i18n="options_language_label">Language</label>
-              </div>
-            
-              <div class="floating-label-field">
-                <textarea id="systemPrompt" name="systemPrompt" rows="3"></textarea>
-                <label for="systemPrompt" class="floating-label" data-i18n="options_system_prompt_label">System Prompt</label>
-              </div>
 
-              <div class="form-group">
-                <label class="toggle-switch-label" data-i18n-title="options_filter_cot_tooltip" title="When enabled, content before </think> tags will be filtered out during streaming output">
-                  <span class="toggle-switch">
-                    <input type="checkbox" id="filterCOT" name="filterCOT">
-                    <span class="slider"></span>
-                  </span>
-                  <span data-i18n="options_filter_cot_label">Filter COT (Chain of Thought) in streaming output</span>
-                </label>
-              </div>
+                <div class="floating-label-field">
+                  <select id="theme" name="theme">
+                    <option value="light" data-i18n="options_theme_light">Light</option>
+                    <option value="dark" data-i18n="options_theme_dark">Dark</option>
+                    <option value="system" data-i18n="options_theme_system">System</option>
+                  </select>
+                  <label for="theme" class="floating-label" data-i18n="options_theme_label">Theme</label>
+                </div>
+
+                <div class="floating-label-field">
+                  <select id="languageSelector" name="language">
+                    <option value="en" data-i18n="options_language_english">English</option>
+                    <option value="zh_CN" data-i18n="options_language_chinese">简体中文</option>
+                    <!-- More languages can be added here -->
+                  </select>
+                  <label for="languageSelector" class="floating-label" data-i18n="options_language_label">Language</label>
+                </div>
+
+                <div class="floating-label-field">
+                  <textarea id="systemPrompt" name="systemPrompt" rows="3"></textarea>
+                  <label for="systemPrompt" class="floating-label" data-i18n="options_system_prompt_label">System Prompt</label>
+                </div>
+
+                <div class="form-group">
+                  <label class="toggle-switch-label" data-i18n-title="options_filter_cot_tooltip" title="When enabled, content before </think> tags will be filtered out during streaming output">
+                    <span class="toggle-switch">
+                      <input type="checkbox" id="filterCOT" name="filterCOT">
+                      <span class="slider"></span>
+                    </span>
+                    <span data-i18n="options_filter_cot_label">Filter COT (Chain of Thought) in streaming output</span>
+                  </label>
+                </div>
+              </section>
+
+              <section class="settings-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_content_extraction_title">Content Extraction</h2>
+                </div>
+
+                <div class="floating-label-field">
+                  <input type="number" id="contentDisplayHeight" name="contentDisplayHeight" min="0" max="600">
+                  <label for="contentDisplayHeight" class="floating-label" data-i18n="options_extracted_content_height_label">Extracted Content Height</label>
+                </div>
+
+                <div class="floating-label-field">
+                  <select id="defaultExtractionMethod" name="defaultExtractionMethod">
+                    <option value="readability" data-i18n="options_extraction_method_readability">Readability.js (Default)</option>
+                    <option value="jina" data-i18n="options_extraction_method_jina">Jina AI</option>
+                  </select>
+                  <label for="defaultExtractionMethod" class="floating-label" data-i18n="options_default_extraction_method_label">Default Extraction Method</label>
+                </div>
+
+                <div class="floating-label-field" id="jinaApiKeyGroup">
+                  <input type="password" id="jinaApiKey" name="jinaApiKey">
+                  <label for="jinaApiKey" class="floating-label" data-i18n="options_jina_api_key_label">Jina AI API Key (Optional)</label>
+                </div>
+
+                <div class="floating-label-field" id="jinaResponseTemplateGroup">
+                  <textarea id="jinaResponseTemplate" name="jinaResponseTemplate" rows="3"></textarea>
+                  <label for="jinaResponseTemplate" class="floating-label" data-i18n="options_jina_response_template_label">Jina AI Response Template</label>
+                  <small data-i18n="options_jina_response_template_description">Template for formatting Jina AI JSON response. Available placeholders: {title}, {url}, {description}, {content}.</small>
+                </div>
+              </section>
             </section>
 
-            <!-- Content Extraction Settings -->
-            <section class="settings-section sidebar-section">
-              <h2 data-i18n="options_content_extraction_title">Content Extraction</h2>
-              
-              <div class="floating-label-field">
-                <input type="number" id="contentDisplayHeight" name="contentDisplayHeight" min="0" max="600">
-                <label for="contentDisplayHeight" class="floating-label" data-i18n="options_extracted_content_height_label">Extracted Content Height</label>
-              </div>
-              
-              <div class="floating-label-field">
-                <select id="defaultExtractionMethod" name="defaultExtractionMethod">
-                  <option value="readability" data-i18n="options_extraction_method_readability">Readability.js (Default)</option>
-                  <option value="jina" data-i18n="options_extraction_method_jina">Jina AI</option>
-                </select>
-                <label for="defaultExtractionMethod" class="floating-label" data-i18n="options_default_extraction_method_label">Default Extraction Method</label>
-              </div>
-              
-              <div class="floating-label-field" id="jinaApiKeyGroup">
-                <input type="password" id="jinaApiKey" name="jinaApiKey">
-                <label for="jinaApiKey" class="floating-label" data-i18n="options_jina_api_key_label">Jina AI API Key (Optional)</label>
-              </div>
-              
-              <div class="floating-label-field" id="jinaResponseTemplateGroup">
-                <textarea id="jinaResponseTemplate" name="jinaResponseTemplate" rows="3"></textarea>
-                <label for="jinaResponseTemplate" class="floating-label" data-i18n="options_jina_response_template_label">Jina AI Response Template</label>
-                <small data-i18n="options_jina_response_template_description">Template for formatting Jina AI JSON response. Available placeholders: {title}, {url}, {description}, {content}.</small>
-              </div>
+            <section id="tab-quick-inputs" class="tab-panel" role="tabpanel" hidden>
+              <section class="settings-section main-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_quick_input_tabs_title">Quick Input Tabs</h2>
+                  <button type="button" id="addQuickInputBtn" class="add-model-btn-inline">
+                    <i class="material-icons">add</i>
+                    <span data-i18n="options_add_quick_input_button">Add Quick Input</span>
+                  </button>
+                </div>
+                <div class="quick-inputs-section">
+                  <div id="quickInputsContainer" class="quick-inputs-container">
+                    <!-- Quick input items will be added here dynamically -->
+                  </div>
+                </div>
+              </section>
             </section>
 
-            <!-- Theme -->
-           
+            <section id="tab-models" class="tab-panel" role="tabpanel" hidden>
+              <section class="settings-section main-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_language_models_title">Language Models</h2>
+                  <button type="button" id="addModelBtn" class="add-model-btn-inline">
+                    <i class="material-icons">add</i>
+                    <span data-i18n="options_add_new_model_button">Add New Model</span>
+                  </button>
+                </div>
+                <div class="models-section">
+                  <div id="modelsContainer" class="models-container vertical-layout">
+                    <!-- Model configurations will be added here dynamically -->
+                  </div>
+                </div>
+              </section>
+            </section>
 
-            <!-- Cloud Sync Settings -->
-            <section class="settings-section sidebar-section">
-              <h2 data-i18n="options_cloud_sync_title">Cloud Sync</h2>
-              <p><small data-i18n="options_cloud_sync_description" data-i18n-html>
-                Sync your config (<strong>INCLUDE api-key</strong>) and data
-              </small>
-            </p>
+            <section id="tab-cloud-sync" class="tab-panel" role="tabpanel" hidden>
+              <section class="settings-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_cloud_sync_title">Cloud Sync</h2>
+                </div>
+                <p><small data-i18n="options_cloud_sync_description" data-i18n-html>
+                  Sync your config (<strong>INCLUDE api-key</strong>) and data
+                </small>
+              </p>
 
-              <!-- Storage Type Selection -->
-              <div class="floating-label-field">
-                <select id="storageType" name="storageType">
-                  <option value="gist" data-i18n="options_storage_type_gist">GitHub Gist</option>
-                  <option value="webdav" data-i18n="options_storage_type_webdav">WebDAV</option>
-                </select>
-                <label for="storageType" class="floating-label" data-i18n="options_storage_type_label">Storage Type</label>
-              </div>
-
-              <!-- Gist Configuration -->
-              <div id="gistConfigGroup" class="sync-config-group" style="display: block;">
+                <!-- Storage Type Selection -->
                 <div class="floating-label-field">
-                  <input type="password" id="gistToken" name="gistToken">
-                  <label for="gistToken" class="floating-label" data-i18n="common_github_token">GitHub Token</label>
-                  <small><a href="https://github.com/settings/tokens" target="_blank" data-i18n="options_github_token_create_link">Create token</a><span data-i18n="options_github_token_permission_note">(Requires Gist permission)</span></small>
+                  <select id="storageType" name="storageType">
+                    <option value="gist" data-i18n="options_storage_type_gist">GitHub Gist</option>
+                    <option value="webdav" data-i18n="options_storage_type_webdav">WebDAV</option>
+                  </select>
+                  <label for="storageType" class="floating-label" data-i18n="options_storage_type_label">Storage Type</label>
                 </div>
 
-                <div class="floating-label-field">
-                  <input type="text" id="gistId" name="gistId">
-                  <label for="gistId" class="floating-label" data-i18n="options_gist_id_label">Secret Gist ID</label>
-                  <small><span data-i18n="options_gist_id_create_link_prefix">Create a </span><a href="https://gist.github.com/" target="_blank" data-i18n="options_gist_id_create_link">secret Gist</a><span data-i18n="options_gist_id_create_link_suffix">(DO NOT create public gist)</span></small>
-                </div>
-              </div>
+                <!-- Gist Configuration -->
+                <div id="gistConfigGroup" class="sync-config-group" style="display: block;">
+                  <div class="floating-label-field">
+                    <input type="password" id="gistToken" name="gistToken">
+                    <label for="gistToken" class="floating-label" data-i18n="common_github_token">GitHub Token</label>
+                    <small><a href="https://github.com/settings/tokens" target="_blank" data-i18n="options_github_token_create_link">Create token</a><span data-i18n="options_github_token_permission_note">(Requires Gist permission)</span></small>
+                  </div>
 
-              <!-- WebDAV Configuration -->
-              <div id="webdavConfigGroup" class="sync-config-group" style="display: none;">
-                <div class="floating-label-field">
-                  <input type="url" id="webdavUrl" name="webdavUrl" placeholder=" ">
-                  <label for="webdavUrl" class="floating-label" data-i18n="options_webdav_url_label">WebDAV URL</label>                  
-                </div>
-
-                <div class="floating-label-field">
-                  <input type="text" id="webdavUsername" name="webdavUsername" placeholder=" ">
-                  <label for="webdavUsername" class="floating-label" data-i18n="options_webdav_username_label">Username</label>
-                </div>
-
-                <div class="floating-label-field">
-                  <input type="password" id="webdavPassword" name="webdavPassword" placeholder=" ">
-                  <label for="webdavPassword" class="floating-label" data-i18n="options_webdav_password_label">Password</label>
-                </div>
-              </div>
-
-              <div id="syncConfigGroup" class="sync-config-group">
-
-                <div class="form-group sync-controls">
-                  <div class="sync-toggle-container">
-                    <label class="toggle-switch-label">
-                      <span class="toggle-switch">
-                        <input type="checkbox" id="syncEnabled" name="syncEnabled">
-                        <span class="slider"></span>
-                      </span>
-                      <span data-i18n="options_sync_on_save_label">Sync when Save</span>
-                    </label>
+                  <div class="floating-label-field">
+                    <input type="text" id="gistId" name="gistId">
+                    <label for="gistId" class="floating-label" data-i18n="options_gist_id_label">Secret Gist ID</label>
+                    <small><span data-i18n="options_gist_id_create_link_prefix">Create a </span><a href="https://gist.github.com/" target="_blank" data-i18n="options_gist_id_create_link">secret Gist</a><span data-i18n="options_gist_id_create_link_suffix">(DO NOT create public gist)</span></small>
                   </div>
                 </div>
 
-                <div class="sync-status" id="syncStatus">
-                  <div class="status-details" id="syncStatusDetails">
-                    <div class="status-text" id="syncStatusText" data-i18n="options_sync_status_not_configured">Not configured</div>
-                    <small id="syncErrorMessage" class="error-message" style="display: none;"></small>
+                <!-- WebDAV Configuration -->
+                <div id="webdavConfigGroup" class="sync-config-group" style="display: none;">
+                  <div class="floating-label-field">
+                    <input type="url" id="webdavUrl" name="webdavUrl" placeholder=" ">
+                    <label for="webdavUrl" class="floating-label" data-i18n="options_webdav_url_label">WebDAV URL</label>
+
                   </div>
+
+                  <div class="floating-label-field">
+                    <input type="text" id="webdavUsername" name="webdavUsername" placeholder=" ">
+                    <label for="webdavUsername" class="floating-label" data-i18n="options_webdav_username_label">Username</label>
+                  </div>
+
+                  <div class="floating-label-field">
+                    <input type="password" id="webdavPassword" name="webdavPassword" placeholder=" ">
+                    <label for="webdavPassword" class="floating-label" data-i18n="options_webdav_password_label">Password</label>
+                  </div>
+
+                  <div class="floating-label-field">
+                    <input type="text" id="webdavDirectory" name="webdavDirectory" placeholder=" ">
+                    <label for="webdavDirectory" class="floating-label" data-i18n="options_webdav_directory_label">Directory (Optional)</label>
+                  </div>
+
                 </div>
 
+                <div id="syncConfigGroup" class="sync-config-group">
 
-              </div>
-            </section>
+                  <div class="form-group sync-controls">
+                    <div class="sync-toggle-container">
+                      <label class="toggle-switch-label">
+                        <span class="toggle-switch">
+                          <input type="checkbox" id="syncEnabled" name="syncEnabled">
+                          <span class="slider"></span>
+                        </span>
+                        <span data-i18n="options_sync_on_save_label">Sync when Save</span>
+                      </label>
+                    </div>
+                  </div>
 
-            <!-- Blacklist Settings -->
-            <section class="settings-section sidebar-section">
-              <h2 data-i18n="options_blacklist_settings_title">Blacklist Settings</h2>
-              <div class="blacklist-description">
-                <p data-i18n="options_blacklist_description">Confirm before run Think Bot</p>
-              </div>
+                  <div class="sync-status" id="syncStatus">
+                    <div class="status-details" id="syncStatusDetails">
+                      <div class="status-text" id="syncStatusText" data-i18n="options_sync_status_not_configured">Not configured</div>
+                      <small id="syncErrorMessage" class="error-message" style="display: none;"></small>
+                    </div>
+                  </div>
 
-              <div class="blacklist-controls">
-                <button type="button" id="addBlacklistBtn" class="secondary-btn small-btn">
-                  <i class="material-icons">add</i>
-                  <span data-i18n="common_add">Add</span>
-                </button>
-                <button type="button" id="resetBlacklistBtn" class="secondary-btn small-btn">
-                  <i class="material-icons">refresh</i>
-                  <span data-i18n="common_reset">Reset</span>
-                </button>
-              </div>
-
-              <div class="blacklist-table-container">
-                <table class="blacklist-table">
-                  <thead>                  
-                  </thead>
-                  <tbody id="blacklistTableBody">
-                    <!-- Dynamic content will be inserted here -->
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          </div>
-
-          <!-- Right Main Content Area -->
-          <div class="right-content">
-            <!-- Quick Input Tabs -->
-            <section class="settings-section main-section">
-              <div class="section-header">
-                <h2 data-i18n="options_quick_input_tabs_title">Quick Input Tabs</h2>
-                <button type="button" id="addQuickInputBtn" class="add-model-btn-inline">
-                  <i class="material-icons">add</i>
-                  <span data-i18n="options_add_quick_input_button">Add Quick Input</span>
-                </button>
-              </div>
-              <div class="quick-inputs-section">
-                <div id="quickInputsContainer" class="quick-inputs-container">
-                  <!-- Quick input items will be added here dynamically -->
                 </div>
-              </div>
+              </section>
             </section>
 
-            <!-- Language Models -->
-            <section class="settings-section main-section">
-              <div class="section-header">
-                <h2 data-i18n="options_language_models_title">Language Models</h2>
-                <button type="button" id="addModelBtn" class="add-model-btn-inline">
-                  <i class="material-icons">add</i>
-                  <span data-i18n="options_add_new_model_button">Add New Model</span>
-                </button>
-              </div>
-              <div class="models-section">
-                <div id="modelsContainer" class="models-container vertical-layout">
-                  <!-- Model configurations will be added here dynamically -->
+            <section id="tab-blacklist" class="tab-panel" role="tabpanel" hidden>
+              <section class="settings-section">
+                <div class="section-header">
+                  <h2 data-i18n="options_blacklist_settings_title">Blacklist Settings</h2>
                 </div>
-              </div>
+                <div class="blacklist-description">
+                  <p data-i18n="options_blacklist_description">Confirm before run Think Bot</p>
+                </div>
+
+                <div class="blacklist-controls">
+                  <button type="button" id="addBlacklistBtn" class="secondary-btn small-btn">
+                    <i class="material-icons">add</i>
+                    <span data-i18n="common_add">Add</span>
+                  </button>
+                  <button type="button" id="resetBlacklistBtn" class="secondary-btn small-btn">
+                    <i class="material-icons">refresh</i>
+                    <span data-i18n="common_reset">Reset</span>
+                  </button>
+                </div>
+
+                <div class="blacklist-table-container">
+                  <table class="blacklist-table">
+                    <thead>
+                    </thead>
+                    <tbody id="blacklistTableBody">
+                      <!-- Dynamic content will be inserted here -->
+                    </tbody>
+                  </table>
+                </div>
+              </section>
             </section>
           </div>
         </div>

--- a/options/styles/layout.css
+++ b/options/styles/layout.css
@@ -55,57 +55,75 @@
   font-weight: 500;
 }
 
-/* Two Column Layout */
-.main-content-wrapper {
+/* Tabbed Layout */
+.tabbed-layout {
   display: grid;
-  grid-template-columns: 22% 1fr;
-  grid-gap: 0;
+  grid-template-columns: 220px 1fr;
+  gap: 0;
   align-items: start;
   padding: 0 1rem;
   max-width: 1400px;
   margin: 0 auto;
 }
 
-/* Left Sidebar */
-.left-sidebar {
-  background-color: transparent;
-  padding: 1rem;
+.tab-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem 0.75rem 1rem 0;
   border-right: 1px solid var(--divider-color);
-  padding-right: 1.5rem;
-  margin-right: 1.5rem;
+  position: sticky;
+  top: 80px;
 }
 
-.sidebar-section {
-  background: none !important;
-  border: none !important;
-  box-shadow: none !important;
-  padding: 0 !important;
-  margin-bottom: 1.5rem;
-  border-bottom: 1px solid var(--divider-color);
-  padding-bottom: 1.5rem;
-}
-
-.sidebar-section:last-child {
-  margin-bottom: 0;
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.sidebar-section h2 {
-  color: var(--primary-color);
-  margin: 0 0 0.6rem 0;
-  font-size: 0.95rem;
+.tab-button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.6rem 0.85rem;
+  border: none;
+  background: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
   font-weight: 500;
-  padding-bottom: 0.3rem;
-  border-bottom: 1px solid var(--divider-color);
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--transition-normal) ease, color var(--transition-normal) ease, box-shadow var(--transition-normal) ease;
 }
 
-/* Right Content Area */
-.right-content {
+.tab-button:hover,
+.tab-button:focus {
+  outline: none;
+  background-color: var(--hover-color);
+  color: var(--primary-color);
+}
+
+.tab-button.active {
+  background-color: var(--primary-color-lightest);
+  color: var(--primary-color);
+  box-shadow: inset 0 0 0 1px var(--primary-color-light);
+}
+
+.tab-panels {
+  padding: 1rem 0 1.5rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  padding: 0;
+}
+
+.tab-panel {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tab-panel.active {
+  display: flex;
+}
+
+.tab-panel[hidden] {
+  display: none !important;
 }
 
 .main-section {

--- a/options/styles/models.css
+++ b/options/styles/models.css
@@ -13,24 +13,18 @@
 }
 
 .models-container.vertical-layout {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.75rem;
-}
-
-.models-container.vertical-layout .model-config-item {
-  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .model-config-item {
-  display: flex;
-  flex-direction: column;
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
-  margin-bottom: 0;
-  transition: all var(--transition-normal) ease;
-  padding: 0.75rem;
   box-shadow: var(--shadow-sm);
+  transition: all var(--transition-normal) ease;
+  overflow: hidden;
+  border-radius: 8px;
 }
 
 .model-config-item:hover {
@@ -38,70 +32,124 @@
   border-color: var(--border-color-hover);
 }
 
-.model-config-item.disabled .model-details-column {
+.model-config-item.disabled .model-details {
   opacity: 0.5;
   pointer-events: none;
 }
 
-/* When a model is disabled we still want the action controls (toggle/remove)
-   to be clickable so the user can re-enable or remove the entry. The global
-   `.disabled { pointer-events: none }` rule (in base.css) would block clicks
-   for the whole item; override it here for the actions column only. */
-.model-config-item.disabled .model-actions-column {
-  pointer-events: auto; /* allow click events on actions */
+.model-config-item.disabled .model-header-actions {
+  pointer-events: auto;
 }
 
-.model-config-item.disabled .model-actions-column .model-toggle,
-.model-config-item.disabled .model-actions-column .remove-model-btn {
-  pointer-events: auto; /* ensure the inner controls are interactive */
+.model-config-item.disabled .model-header-actions .model-toggle,
+.model-config-item.disabled .model-header-actions .remove-model-btn,
+.model-config-item.disabled .model-header-actions .model-expand-btn {
+  pointer-events: auto;
 }
 
-/* Model card header row with handle and actions */
-.model-card-header {
+.model-item-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
-  padding-bottom: 0.35rem;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
   border-bottom: 1px solid var(--divider-color);
 }
 
-.drag-handle-column {
+.model-header-left {
   display: flex;
   align-items: center;
-  cursor: grab;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1;
 }
 
-.drag-handle-column .drag-handle {
+.drag-handle {
   color: var(--text-secondary);
   display: flex;
   align-items: center;
-  padding: 0.25rem;
+  justify-content: center;
+  padding: 0.35rem;
+  border-radius: 6px;
+  cursor: grab;
   transition: all var(--transition-normal) ease;
 }
 
-.drag-handle-column .drag-handle:hover {
+.drag-handle:hover {
   background-color: var(--hover-color);
   color: var(--primary-color);
 }
 
-.drag-handle-column .drag-handle .material-icons {
+.drag-handle .material-icons {
   font-size: 18px;
 }
 
-/* Model actions column */
-.model-actions-column {
+.model-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.model-summary-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--primary-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.model-summary-divider {
+  opacity: 0.4;
+}
+
+.model-summary-model {
+  max-width: 320px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-header-actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-/* Model details column */
-.model-details-column {
-  flex: 1;
+.model-expand-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--transition-normal) ease;
 }
 
-/* Model form */
+.model-expand-btn .material-icons {
+  transition: transform var(--transition-normal) ease;
+}
+
+.model-config-item.expanded .model-expand-btn .material-icons {
+  transform: rotate(180deg);
+}
+
+.model-details {
+  display: none;
+  padding: 0.75rem 1rem 1rem 1rem;
+}
+
+.model-config-item.expanded .model-details {
+  display: block;
+}
+
 .model-form {
   width: 100%;
 }

--- a/options/styles/responsive.css
+++ b/options/styles/responsive.css
@@ -2,56 +2,53 @@
 
 /* Large screens: dual column with 3 right columns */
 @media (min-width: 1201px) {
-  .main-content-wrapper {
-    grid-template-columns: 22% 1fr;
+  .tabbed-layout {
+    grid-template-columns: 240px 1fr;
   }
 }
 
-/* Medium-large screens: dual column with 2 right columns */
+/* Medium-large screens */
 @media (max-width: 1200px) and (min-width: 901px) {
-  .main-content-wrapper {
-    grid-template-columns: 30% 1fr;
+  .tabbed-layout {
+    grid-template-columns: 200px 1fr;
   }
 }
 
-/* Medium screens: dual column with 1 right column */
+/* Medium screens */
 @media (max-width: 900px) and (min-width: 601px) {
-  .main-content-wrapper {
-    grid-template-columns: 45% 1fr;
+  .tabbed-layout {
+    grid-template-columns: 180px 1fr;
+  }
+  .tab-list {
+    top: 72px;
   }
 }
 
-/* Small screens: single column */
+/* Small screens: stack tabs above content */
 @media (max-width: 600px) {
-  .main-content-wrapper {
+  .tabbed-layout {
     grid-template-columns: 1fr;
     gap: 1rem;
+    padding: 0 1rem;
   }
 
-  .left-sidebar {
-    order: 2;
+  .tab-list {
+    flex-direction: row;
+    flex-wrap: wrap;
     border-right: none;
-    border-top: 1px solid var(--divider-color);
-    padding-right: 1rem;
-    padding-top: 1.5rem;
-    margin-right: 0;
-    margin-top: 1.5rem;
+    border-bottom: 1px solid var(--divider-color);
+    padding: 0 0 1rem 0;
+    gap: 0.5rem;
+    position: static;
   }
 
-  /* Adjust sidebar section spacing for mobile */
-  .sidebar-section {
-    margin-bottom: 1rem !important;
-    padding-bottom: 1rem !important;
+  .tab-button {
+    flex: 1 1 calc(50% - 0.5rem);
+    justify-content: center;
   }
 
-  .sidebar-section:last-child {
-    margin-bottom: 0 !important;
-    border-bottom: none !important;
-    padding-bottom: 0 !important;
-  }
-
-  .right-content {
-    order: 1;
+  .tab-panels {
+    padding: 0;
   }
 
   .header-row {
@@ -128,7 +125,7 @@
     padding: 0 0.5rem;
   }
 
-  .main-content-wrapper {
+  .tabbed-layout {
     padding: 0 0.5rem;
   }
 


### PR DESCRIPTION
## Summary
- convert the options page to a left-hand tabbed layout that groups basic, quick input, model, sync, and blacklist settings
- add front-end tab switching logic and responsive styling for the new layout
- restyle the language model list into a full-width sortable list with collapsible detail panels

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68da6bf44ea88330bcbfd37d203e4711