### PR TITLE
Adjust branch preview trigger icon styling

### DIFF
--- a/sidebar/styles/chat.css
+++ b/sidebar/styles/chat.css
@@ -715,18 +715,18 @@
 .branch-preview-trigger {
   background: transparent;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  padding: 2px;
+  padding: 1px;
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .branch-preview-trigger .material-icons {
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .branch-preview-trigger:hover,


### PR DESCRIPTION
## Summary
- update the branch preview trigger button to use a smaller padding and icon size
- switch the trigger color to the shared secondary text gray for a muted appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68db8e7c0e0c8330ae43bdba66999c2e