### PR TITLE
Fix sync of branch models and preserve order timestamps

### DIFF
--- a/options/modules/model-manager.js
+++ b/options/modules/model-manager.js
@@ -502,7 +502,7 @@ export class ModelManager {
     this.updateDefaultModelSelector();
     logger.info('Added new model');
     if (this.changeCallback) {
-      this.changeCallback();
+      this.changeCallback('order');
     }
   }
 
@@ -538,9 +538,9 @@ export class ModelManager {
     
     const sourceModelName = sourceModel.name || i18n.getMessage('options_model_unnamed') || 'Unnamed Model';
     logger.info(`Copied model "${sourceModelName}" with new ID: ${copiedModel.id}`);
-    
+
     if (this.changeCallback) {
-      this.changeCallback();
+      this.changeCallback('order');
     }
   }
 
@@ -567,7 +567,7 @@ export class ModelManager {
         this.updateDefaultModelSelector();
         logger.info(`Soft deleted model "${modelName}" at index ${index}`);
         if (this.changeCallback) {
-          this.changeCallback();
+          this.changeCallback('order');
         }
       }
     });
@@ -1139,8 +1139,11 @@ export class ModelManager {
         this.renderModels();
 
         // Notify that changes have been made
+        if (window.optionsPage?.touchModelOrderLastModified) {
+          window.optionsPage.touchModelOrderLastModified();
+        }
         if (this.changeCallback) {
-          this.changeCallback();
+          this.changeCallback('order');
         }
       },
     });

--- a/options/modules/quick-inputs.js
+++ b/options/modules/quick-inputs.js
@@ -230,9 +230,12 @@ export class QuickInputsManager {
       animation: 150, // ms, animation speed moving items when sorting
       handle: '.drag-handle', // Drag handle selector within list items
       onEnd: () => {
+        if (window.optionsPage?.touchQuickInputsOrderLastModified) {
+          window.optionsPage.touchQuickInputsOrderLastModified();
+        }
         // Trigger change callback to mark as unsaved
         if (this.changeCallback) {
-          this.changeCallback();
+          this.changeCallback('order');
         }
       }
     });
@@ -329,7 +332,7 @@ export class QuickInputsManager {
     }
     
     if (this.changeCallback) {
-      this.changeCallback();
+      this.changeCallback('content');
     }
   }
 
@@ -377,8 +380,11 @@ export class QuickInputsManager {
     // Add quick input button
     domElements.addQuickInputBtn.addEventListener('click', () => {
       this.addQuickInput(domElements);
+      if (window.optionsPage?.touchQuickInputsOrderLastModified) {
+        window.optionsPage.touchQuickInputsOrderLastModified();
+      }
       if (this.changeCallback) {
-        this.changeCallback();
+        this.changeCallback('order');
       }
     });
     
@@ -401,8 +407,11 @@ export class QuickInputsManager {
             onConfirm: () => {
               console.log(`Removing quick input: ${displayText}`);
               this.removeQuickInput(item);
+              if (window.optionsPage?.touchQuickInputsOrderLastModified) {
+                window.optionsPage.touchQuickInputsOrderLastModified();
+              }
               if (this.changeCallback) {
-                this.changeCallback();
+                this.changeCallback('order');
               }
             }
           });
@@ -462,9 +471,9 @@ export class QuickInputsManager {
         e.target.classList.contains('auto-trigger-checkbox')
       ) {
         if (this.changeCallback) {
-          this.changeCallback();
+          this.changeCallback('content');
         }
       }
     });
   }
-} 
+}

--- a/options/modules/ui-config-manager.js
+++ b/options/modules/ui-config-manager.js
@@ -105,11 +105,14 @@ export class UIConfigManager {
     // Delegate quick inputs extraction to QuickInputsManager to handle soft deletes
     const quickInputs = QuickInputsManager.getQuickInputs(domElements);
 
+    const optionsPage = window.optionsPage;
     const config = {
       llm_models: {
-        models: modelManager.getAllModels() // Get all models including soft-deleted ones for proper sync
+        models: modelManager.getAllModels(), // Get all models including soft-deleted ones for proper sync
+        orderLastModified: optionsPage?.getModelOrderLastModified?.() || 0
       },
       quickInputs: quickInputs,
+      quickInputsOrderLastModified: optionsPage?.getQuickInputsOrderLastModified?.() || 0,
       basic: {
         defaultExtractionMethod: domElements.defaultExtractionMethod.value,
         jinaApiKey: domElements.jinaApiKey.value,


### PR DESCRIPTION
## Summary
- track quick input and LLM model order changes in the options UI and include their timestamps in saved config
- account for branch model selections when calculating modification timestamps so tab-specific settings sync correctly
- respect the new order timestamps during sync merges for quick inputs and models to keep ordering consistent

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68db97b7dea483308c313dbf92dcab0b