### PR TITLE
Adjust conversation header typography

### DIFF
--- a/conversations/conversations.css
+++ b/conversations/conversations.css
@@ -392,7 +392,7 @@
 
 .page-info-header .page-title {
   margin: 0 0 6px 0;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--text-color);
   white-space: nowrap;
@@ -421,7 +421,7 @@
 
 .page-info-header .page-title.edit-mode .title-input {
   width: 100%;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--text-color);
   background-color: var(--input-background, var(--background-color));
@@ -446,10 +446,11 @@
 }
 
 .page-url-container {
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .page-url {
+  font-size: 10px;
   color: var(--accent-color);
   text-decoration: none;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- decrease the conversation header title font size for a more compact layout
- reduce the URL font size so it appears smaller than the title while preserving readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dde26dab7883308729aebe66b94920