### PR TITLE
Stabilize branch dropdown anchor during loading

### DIFF
--- a/sidebar/modules/chat-history.js
+++ b/sidebar/modules/chat-history.js
@@ -821,6 +821,10 @@ const createModelDropdown = (button, branchId) => {
   const dropdown = document.createElement('div');
   dropdown.className = 'model-dropdown';
   dropdown.setAttribute('data-anchor-branch-id', branchId);
+
+  // Capture the button position immediately in case the loading-state UI swaps
+  // out the branch action buttons before the async model list resolves
+  const anchorRect = button.getBoundingClientRect();
   
   // Get available model list
   getAvailableModels().then(models => {
@@ -852,7 +856,8 @@ const createModelDropdown = (button, branchId) => {
     
     // Calculate and set position (below button, avoid overflow)
     const positionDropdown = () => {
-      const buttonRect = button.getBoundingClientRect();
+      const liveRect = button.isConnected ? button.getBoundingClientRect() : null;
+      const buttonRect = (liveRect && liveRect.width && liveRect.height) ? liveRect : anchorRect;
       const dropdownRect = dropdown.getBoundingClientRect();
       const viewportPadding = 8;
       const offset = 4;

--- a/sidebar/styles/chat.css
+++ b/sidebar/styles/chat.css
@@ -1126,6 +1126,8 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  /* Keep loading-state controls above the sticky model label */
+  z-index: 12;
 }
 
 /* Override general branch action button size for loading state - consistent with base style */


### PR DESCRIPTION
## Summary
- capture the branch button position before the async model list resolves so the dropdown stays anchored even if loading controls swap out
- fall back to the saved rect when the original button is removed during streaming to keep the model list visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925766772808328b6d8f53cfe93722b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture branch button rect and fall back to it if the button is replaced/removed so the model dropdown stays correctly positioned during loading.
> 
> - **Chat sidebar**:
>   - `createModelDropdown`: capture button `getBoundingClientRect()` upfront and use as fallback; on position, prefer live rect if button is still connected and non-zero, else use saved rect to keep dropdown anchored during loading/streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5edfa190cf28d96de79fd41e8c04ccd437e736e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->